### PR TITLE
ci: enforce Conventional Commits format for PR titles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,6 +13,10 @@ uv pip install -e .        # editable install
 uv build                   # build sdist/wheel
 ```
 
+## PR Titles
+
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat: add feature`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for allowed types.
+
 ## Releases
 
 Releases are automated via GitHub Actions. Push a tag matching `v*.*.*` to trigger a GitHub Release with auto-generated notes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add new feature`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        with:
+          disallowScopes: |
+            .*
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+## PR Title Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for **PR titles**. Since we squash-merge, the PR title becomes the final commit message.
+
+### Format
+
+```
+type: description
+```
+
+### Allowed Types
+
+| Type | Purpose |
+|------|---------|
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation only |
+| `style` | Code style (formatting, semicolons, etc.) |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf` | Performance improvement |
+| `test` | Adding or updating tests |
+| `build` | Build system or external dependencies |
+| `ci` | CI configuration |
+| `chore` | Other changes that don't modify src or test files |
+| `revert` | Reverts a previous commit |
+
+### Examples
+
+- `feat: add user authentication`
+- `fix: handle empty input`
+- `docs: update installation instructions`
+
+### Individual Commits
+
+Individual commit messages within a PR are free-form. Only the PR title is enforced.


### PR DESCRIPTION
## Summary

- Add CI workflow (`pr-title.yml`) using `amannn/action-semantic-pull-request@v6` to validate PR titles against Conventional Commits format
- Add `CONTRIBUTING.md` documenting the allowed types and format
- Add PR template with a checklist reminder
- Update `.claude/CLAUDE.md` with the PR title convention

## Test plan

- [ ] Open a PR with a non-conforming title (e.g., "update stuff") → CI check should fail
- [ ] Rename PR to a valid title (e.g., "feat: add stuff") → CI check should pass
- [ ] Confirm the PR template shows the checklist when opening a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)