### PR TITLE
fix: inline URL in cliff.toml body template

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -4,10 +4,6 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 body = """
-{%- macro remote_url() -%}
-  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
-{%- endmacro -%}
-
 {% if version -%}
   ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else -%}
@@ -18,7 +14,7 @@ body = """
   ### {{ group | striptags | trim | upper_first }}
   {% for commit in commits %}
     - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | upper_first }} \
-      ([{{ commit.id | truncate(length=7, end="") }}]({{ remote_url() }}/commit/{{ commit.id }}))\
+      ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/commit/{{ commit.id }}))\
       {%- if commit.breaking %} **BREAKING**{% endif -%}
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
## Summary

- Remove the `remote_url()` Tera macro from the git-cliff body template and inline the URL directly
- Fixes the `Function 'remote_url' not found` error that caused the Changelog workflow to fail

## Test plan

- [ ] Merge this PR
- [ ] Re-run the Changelog workflow (or push a new `u` tag)
- [ ] Verify CHANGELOG.md is generated and committed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)