### PR TITLE
docs: fix release notes description in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,4 +23,4 @@ Releases use a two-tag flow:
 
 1. Bump version with `hatch version <rule>`, commit, tag `u<version>`, push.
 2. The Changelog workflow (triggered by the `u` tag) generates `CHANGELOG.md`, commits it, creates the `v` tag, and pushes.
-3. The Release workflow (triggered via `workflow_run` after Changelog) creates a GitHub Release with git-cliff release notes.
+3. The Release workflow (triggered via `workflow_run` after Changelog) creates a GitHub Release with GitHub auto-generated notes.


### PR DESCRIPTION
## Summary
- Corrects the Releases section in CLAUDE.md: the Release workflow uses GitHub auto-generated notes (`gh release create --generate-notes`), not git-cliff release notes.

## Test plan
- [x] Verified against `.github/workflows/release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)