### PR TITLE
chore: ignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-# uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.


### PR DESCRIPTION
## Summary
- Uncomment `uv.lock` in `.gitignore` so the lock file is not tracked

## Test plan
- [ ] Verify `uv.lock` is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)