### PR TITLE
ci: recognize `!` breaking-change marker

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,9 @@ changelog:
       - dependabot
       - dependabot[bot]
   categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
     - title: Features
       labels:
         - feature

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: bcoe/conventional-release-labels@v1
         with:
+          # The "breaking" key is applied when the PR title carries the "!"
+          # Conventional Commits breaking-change marker (e.g., "feat!: ...").
+          # Without it, the action tries to apply a nil label and the GitHub
+          # API rejects the request.
           type_labels: |
             {
               "feat": "feature",
@@ -29,6 +33,7 @@ jobs:
               "build": "build",
               "ci": "ci",
               "chore": "chore",
-              "revert": "revert"
+              "revert": "revert",
+              "breaking": "breaking"
             }
           ignored_types: "[]"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Conventional Commits.
 ## Features
 
 - PR title prefixes (e.g., `feat:`, `fix:`) enforced with [Conventional Commits]
+- Breaking changes marked with `!` (e.g., `feat!:`)
 - PR labels assigned automatically based on the prefix
 - GitHub Releases triggered by version tags
 - Release notes and `CHANGELOG.md` generated from PR titles


### PR DESCRIPTION
## Summary

- `conventional-label.yml`: map the `breaking` type to a `breaking` label. Without this, the action tries to apply a `nil` label and GitHub rejects the request (observed in test PR #25).
- `release.yml`: add a **Breaking Changes** category at the top so `feat!:` PRs surface first.
- `README.md`: note the `!` marker.

## Test plan

- [ ] Workflows pass on this PR
- [ ] Re-verify with a throwaway `feat!: …` PR after merge

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
