### PR TITLE
docs: document `!` breaking-change marker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,25 +12,28 @@ type: description
 
 ### Allowed Types
 
-| Type | Purpose |
-|------|---------|
-| `feat` | A new feature |
-| `fix` | A bug fix |
-| `docs` | Documentation only |
-| `style` | Code style (formatting, semicolons, etc.) |
+| Type       | Purpose                                                 |
+| ---------- | ------------------------------------------------------- |
+| `feat`     | A new feature                                           |
+| `fix`      | A bug fix                                               |
+| `docs`     | Documentation only                                      |
+| `style`    | Code style (formatting, semicolons, etc.)               |
 | `refactor` | Code change that neither fixes a bug nor adds a feature |
-| `perf` | Performance improvement |
-| `test` | Adding or updating tests |
-| `build` | Build system or external dependencies |
-| `ci` | CI configuration |
-| `chore` | Other changes that don't modify src or test files |
-| `revert` | Reverts a previous commit |
+| `perf`     | Performance improvement                                 |
+| `test`     | Adding or updating tests                                |
+| `build`    | Build system or external dependencies                   |
+| `ci`       | CI configuration                                        |
+| `chore`    | Other changes that don't modify src or test files       |
+| `revert`   | Reverts a previous commit                               |
+
+Append `!` to indicate breaking changes (e.g., `feat!: description`).
 
 ### Examples
 
 - `feat: add user authentication`
 - `fix: handle empty input`
 - `docs: update installation instructions`
+- `feat!: remove get_user()`
 
 ### Individual Commits
 


### PR DESCRIPTION
## Summary

- Document the Conventional Commits `!` marker for breaking changes in `CONTRIBUTING.md`
- Add a `feat!: remove get_user()` example
- Includes incidental table realignment from running the markdown formatter

The `!` marker is already wired up end-to-end (label workflow → release-notes
category) — this PR just surfaces it to contributors.

## Test plan

- [ ] PR title `docs:` gets the `documentation` label via `conventional-label.yml`
- [ ] Rendered table on GitHub looks correct

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
