### PR TITLE
build: fill in package description and add project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,16 @@
 [project]
 name = "legendary-octo-happiness"
 dynamic = ["version"]
-description = "Add your description here"
+description = "Reference implementation of automated changelog and release workflows using Conventional Commits"
 readme = "README.md"
 authors = [{ name = "Tai Sakuma" }]
 requires-python = ">=3.12"
 license = "MIT"
 dependencies = []
+
+[project.urls]
+Repository = "https://github.com/TaiSakuma/legendary-octo-happiness"
+Changelog = "https://github.com/TaiSakuma/legendary-octo-happiness/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling", "hatch-regex-commit"]


### PR DESCRIPTION
## Summary

`pyproject.toml` still had the placeholder description from `uv init` ("Add your description here"), which ships in the built wheel and sdist metadata. This PR replaces it with the same one-line summary the README uses and adds a `[project.urls]` table (Repository, Changelog).

## Verification

Built the package with `uv build` and inspected the wheel `METADATA`: the `Summary` and both `Project-URL` entries are present.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add new feature`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
