### PR TITLE
ci: add CI workflow with build and type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+# Verify the package on every PR and push to main: build the sdist and
+# wheel, import the package from the built wheel in an isolated
+# environment, and type-check the source with mypy.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      # Install the built wheel into an isolated environment on the
+      # oldest supported Python (requires-python floor) and import it.
+      - name: Import package from built wheel
+        run: |
+          uv run --no-project --python 3.12 --with dist/*.whl \
+            python -c "import legendary_octo_happiness; print(legendary_octo_happiness.hello())"
+
+      - name: Type-check with mypy
+        run: uvx mypy --strict src

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # legendary-octo-happiness
 
 [![GitHub Release][release-badge]][release-url]
+[![CI][ci-badge]][ci-url]
 [![Changelog][changelog-badge]][changelog-url]
 [![Release][release-wf-badge]][release-wf-url]
 [![License: MIT][license-badge]][license-url]
 
 [release-badge]: https://img.shields.io/github/v/release/TaiSakuma/legendary-octo-happiness
 [release-url]: https://github.com/TaiSakuma/legendary-octo-happiness/releases/latest
+[ci-badge]: https://github.com/TaiSakuma/legendary-octo-happiness/actions/workflows/ci.yml/badge.svg
+[ci-url]: https://github.com/TaiSakuma/legendary-octo-happiness/actions/workflows/ci.yml
 [changelog-badge]: https://github.com/TaiSakuma/legendary-octo-happiness/actions/workflows/changelog.yml/badge.svg
 [changelog-url]: https://github.com/TaiSakuma/legendary-octo-happiness/actions/workflows/changelog.yml
 [release-wf-badge]: https://github.com/TaiSakuma/legendary-octo-happiness/actions/workflows/release.yml/badge.svg
@@ -44,11 +47,13 @@ The following workflows run on GitHub Actions:
 
 | Workflow                   | Trigger                      | Purpose                          |
 | -------------------------- | ---------------------------- | -------------------------------- |
+| [`ci.yml`]                 | PR, push to `main`           | Build and type-check the package |
 | [`pr-title.yml`]           | PR opened/edited             | Validate PR title                |
 | [`conventional-label.yml`] | PR opened/edited             | Label PR by convention           |
 | [`changelog.yml`]          | `u*` tag pushed              | Generate `CHANGELOG.md`, `v` tag |
 | [`release.yml`]            | Changelog workflow completed | Create GitHub Release            |
 
+[`ci.yml`]: .github/workflows/ci.yml
 [`pr-title.yml`]: .github/workflows/pr-title.yml
 [`conventional-label.yml`]: .github/workflows/conventional-label.yml
 [`changelog.yml`]: .github/workflows/changelog.yml


### PR DESCRIPTION
## Summary

The repository had no verification CI — nothing built the package, imported it, or type-checked it on PRs. This PR adds `.github/workflows/ci.yml`, which runs on every PR and push to `main` with a single job:

1. `uv build` — build the sdist and wheel, catching packaging regressions
2. Import the package from the built wheel in an isolated environment on Python 3.12 (the `requires-python` floor)
3. `uvx mypy --strict src` — type check (flags on the command line rather than a `[tool.mypy]` section, to stay disjoint from #29's `pyproject.toml` edit)

Both actions (`actions/checkout`, `astral-sh/setup-uv`) are pinned to commit SHAs with version-tag comments, consistent with #32, and Dependabot (already configured for `github-actions`) keeps the pins updated. The README gets a CI badge and a row in the workflows table.

## Verification

Ran the three steps locally from a clean worktree: the build succeeds, the wheel imports and prints the greeting, and mypy reports no issues in 2 source files. This PR also exercises the workflow itself, since `pull_request`-triggered workflows run from the PR branch.

Note: this PR and #33 both edit the README workflows table on adjacent lines; whichever merges second may need a trivial rebase.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add new feature`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
