### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,6 +21,6 @@ jobs:
       contents: write
 
     steps:
-      - uses: TaiSakuma/changelog-commit@v1
+      - uses: TaiSakuma/changelog-commit@b3fbc77d560296e267f3dd34932111a5ef765703 # v1.1.2
         with:
           trigger-tag: ${{ github.ref_name }}

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -15,7 +15,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: bcoe/conventional-release-labels@v1
+      - uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8 # v1.3.1
         with:
           # The "breaking" key is applied when the PR title carries the "!"
           # Conventional Commits breaking-change marker (e.g., "feat!: ...").

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,7 +19,7 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:
           # Regex `.*` rejects all scopes — we don't use scoped prefixes.
           disallowScopes: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Checkout release tag
         id: version
-        uses: TaiSakuma/checkout-version-tag@v1
+        uses: TaiSakuma/checkout-version-tag@920911b2aaaea227efc3a0e50c201aa03ccafa0c # v1.2.0
         with:
           trigger-tag: ${{ github.event.workflow_run.head_branch }}
 
@@ -34,4 +34,4 @@ jobs:
       # Maintain a rolling `latest` tag so users can always reference the
       # most recent release (e.g., in install instructions).
       - name: Tag latest
-        uses: EndBug/latest-tag@v1
+        uses: EndBug/latest-tag@8fcae8848c1e23fd8212258f69a9619bc62cad67 # v1.6.3


### PR DESCRIPTION
## Summary

The workflows referenced actions by mutable version tags (`@v6`, `@v1`) while holding sensitive contexts: `pull_request_target` with `pull-requests: write` in the labeler, and `contents: write` in the release chain. If an upstream tag were moved to a malicious commit, it would run with those permissions. This PR pins every `uses:` in the four existing workflows to the commit SHA its tag currently resolves to, with the exact version kept as a comment:

| Action | Pinned SHA | Version |
| --- | --- | --- |
| `amannn/action-semantic-pull-request` | `48f2562` | v6.1.1 |
| `bcoe/conventional-release-labels` | `886f696` | v1.3.1 |
| `TaiSakuma/changelog-commit` | `b3fbc77` | v1.1.2 |
| `TaiSakuma/checkout-version-tag` | `920911b` | v1.2.0 |
| `EndBug/latest-tag` | `8fcae88` | v1.6.3 |

The `# vX.Y.Z` comment form is the one Dependabot recognizes, and Dependabot is already configured for `github-actions` (daily), so the pins stay updated. The new `ci.yml` from the companion CI PR is created already pinned and is not touched here.

## Verification

Cross-checked each pinned SHA against the GitHub API: dereferencing every commented tag yields exactly the pinned commit SHA. Note the residual limits: `pull_request_target` workflows run from the base branch, so the pinned pr-title/labeler versions are only exercised after merge, and the changelog/release pins at the next release.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add new feature`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
