### PR TITLE
docs: include synchronize trigger in workflows table

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following workflows run on GitHub Actions:
 | Workflow                   | Trigger                      | Purpose                          |
 | -------------------------- | ---------------------------- | -------------------------------- |
 | [`ci.yml`]                 | PR, push to `main`           | Build and type-check the package |
-| [`pr-title.yml`]           | PR opened/edited             | Validate PR title                |
+| [`pr-title.yml`]           | PR opened/edited/synced      | Validate PR title                |
 | [`conventional-label.yml`] | PR opened/edited             | Label PR by convention           |
 | [`changelog.yml`]          | `u*` tag pushed              | Generate `CHANGELOG.md`, `v` tag |
 | [`release.yml`]            | Changelog workflow completed | Create GitHub Release            |


### PR DESCRIPTION
## Summary

The README workflows table said `pr-title.yml` triggers on "PR opened/edited", but the workflow also runs on `synchronize` (its own header comment says "Runs on every PR open/edit/sync"). This PR updates the trigger cell to "PR opened/edited/synced". The `conventional-label.yml` row is unchanged because that workflow has no `synchronize` trigger.

## Verification

The cell now matches the `types` list in `pr-title.yml` (`opened`, `edited`, `synchronize`).

Note: this PR and the companion PR that adds the CI workflow both edit the README workflows table on adjacent lines; whichever merges second may need a trivial rebase.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add new feature`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
