### PR TITLE
docs: fix README accuracy found by the persona review panel

### DIFF
--- a/.claude/rules/diataxis-review.md
+++ b/.claude/rules/diataxis-review.md
@@ -16,10 +16,11 @@ in a section's heading.
 ## Rules
 
 - Every section belongs to exactly one quadrant, **declared by the visible
-  marker in its heading** (legend above; the README explains the markers to
-  its readers in one line). A heading whose subsections span quadrants is a
-  **container**: it carries no marker and at most one orientation sentence
-  of its own, and each subsection declares its own quadrant.
+  marker in its heading** (legend above; the markers are deliberately not
+  explained in the README itself). A heading whose subsections span
+  quadrants is a **container**: it carries no marker and at most one
+  orientation sentence of its own, and each subsection declares its own
+  quadrant.
 - Merging is a same-quadrant operation: the merged section carries exactly
   one declaration, so sections of different quadrants cannot merge —
   imported cross-quadrant content would be bleed by construction. Related

--- a/README.md
+++ b/README.md
@@ -20,17 +20,13 @@
 A reference implementation for automated changelog and release workflows using
 Conventional Commits.
 
-_Heading markers show each section's [Diátaxis] quadrant: 🎓 tutorial,
-🔧 how-to, 📋 reference, 📖 explanation._
-
-[Diátaxis]: https://diataxis.fr/
-
 ## 📖 Features
 
 - PR title prefixes (e.g., `feat:`, `fix:`) enforced with [Conventional Commits]
 - Breaking changes marked with `!` (e.g., `feat!:`)
 - PR labels assigned automatically based on the prefix
-- GitHub Releases triggered by version tags
+- GitHub Releases published automatically after a `u`-prefixed version tag
+  is pushed
 - Release notes and `CHANGELOG.md` generated from PR titles
 
 [Conventional Commits]: https://www.conventionalcommits.org/
@@ -38,25 +34,27 @@ _Heading markers show each section's [Diátaxis] quadrant: 🎓 tutorial,
 ## Release process
 
 1. User tags a version with `u`-prefix (e.g., `u1.2.3`) to the main branch.\*
-2. User pushes the tag to GitHub.
+2. User pushes the commit and the tag to GitHub
+   (`git push origin main --tags`).
 3. GitHub Actions adds a new commit with `CHANGELOG.md` update.
 4. GitHub Actions tags the commit with a `v`-prefixed version (e.g., `v1.2.3`).
 5. GitHub Actions makes a GitHub Release with release notes.
+6. GitHub Actions moves the `latest` tag to the new release.
 
-\* _In this repo, `hatch version <rule>` bumps the version and creates the `u`
-tag._
+\* _In this repo, `hatch version <rule>` (e.g., `hatch version minor`) bumps
+the version, creates the commit, and creates the `u` tag._
 
 ## 📋 GitHub Actions workflows
 
 The following workflows run on GitHub Actions:
 
-| Workflow                   | Trigger                      | Purpose                          |
-| -------------------------- | ---------------------------- | -------------------------------- |
-| [`ci.yml`]                 | PR, push to `main`           | Build and type-check the package |
-| [`pr-title.yml`]           | PR opened/edited/synced      | Validate PR title                |
-| [`conventional-label.yml`] | PR opened/edited             | Label PR by convention           |
-| [`changelog.yml`]          | `u*` tag pushed              | Generate `CHANGELOG.md`, `v` tag |
-| [`release.yml`]            | Changelog workflow completed | Create GitHub Release            |
+| Workflow                   | Trigger                        | Purpose                                  |
+| -------------------------- | ------------------------------ | ---------------------------------------- |
+| [`ci.yml`]                 | PR, push to `main`             | Build and type-check the package         |
+| [`pr-title.yml`]           | PR opened/edited/synced        | Validate PR title                        |
+| [`conventional-label.yml`] | PR opened/edited               | Label PR by convention                   |
+| [`changelog.yml`]          | `u*.*.*` tag pushed            | Generate `CHANGELOG.md`, `v` tag         |
+| [`release.yml`]            | "Generate changelog" completed | Create GitHub Release, move `latest` tag |
 
 [`ci.yml`]: .github/workflows/ci.yml
 [`pr-title.yml`]: .github/workflows/pr-title.yml
@@ -68,9 +66,9 @@ These workflows require the GitHub settings:
 
 - `Settings` > `General` > `Pull Requests`
   - **Disable** "Allow merge commits"
-  - **Enable** "Allow squash merges"
+  - **Enable** "Allow squash merging"
     - Default commit message: "Pull request title and description"
-  - **Disable** "Allow rebase merges"
+  - **Disable** "Allow rebase merging"
 
 ## 📋 Marketplace actions
 


### PR DESCRIPTION
## Summary

First real run of the persona-review system added in #34: the five `readme-persona-*` subagents reviewed the shipped README as a single document (all five returned "revise"), alongside the `/review-readme` mechanical audit. This PR applies the patch-level findings; the structural findings are routed to a full `write-readme` revision that follows.

- **Release process, step 2** — now pushes the commit and the tag (`git push origin main --tags`). The old wording ("User pushes the tag to GitHub"), followed literally, pushed only the tag and failed the Changelog workflow's ancestor check ("Tag … is not on main"). This was the panel's unanimous top finding; `CONTRIBUTING.md` already had the correct command.
- **Release process, new step 6** — a release also moves the rolling `latest` tag (`EndBug/latest-tag` in `release.yml`), previously undocumented anywhere in the README.
- **Footnote** — `hatch version <rule>` also creates the commit (the omission that hid the step-2 bug), with a concrete example (`hatch version minor`).
- **Workflows table** — the changelog trigger cell now shows the exact pattern `u*.*.*` (the old `u*` was looser than the workflow filter — a `u1.2` tag matches "u-prefix" but triggers nothing); the release row names `"Generate changelog"`, the display name `workflow_run` couples on (copying the old cell wording produced a release workflow that never fires), and its purpose cell discloses the `latest`-tag move.
- **Features** — "GitHub Releases triggered by version tags" taught a wrong mental model (a hand-pushed `v` tag triggers nothing in this design); the bullet now names the `u`-prefixed tag that starts the chain.
- **Settings** — verbatim GitHub UI labels: "Allow squash merging" and "Allow rebase merging" (the paraphrased labels were a docs-voice defect).
- **Legend line removed** — the quadrant markers stay on the headings, but the README no longer explains them or introduces Diátaxis; the legend lives only in `.claude/rules/diataxis-review.md`, which this PR updates to match.

## Verification

Mechanical audit checks all pass against the live repository: every local link resolves, table triggers match each workflow's `on:` block, the settings list matches the repository's actual merge settings (verified via the API), and both marketplace links return 200. The step-2 failure mode was confirmed against the pinned `changelog-commit` action source, which verifies the trigger tag is an ancestor of `main` before proceeding.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat: add new feature`). See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
