### PR TITLE
docs: align CONTRIBUTING and CLAUDE with the release-branch model

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,8 +23,8 @@ Use `/review-readme` to audit and update, and `/write-readme` to author or subst
 
 ## Releases
 
-Releases use a two-tag flow:
+Releases use a two-tag flow. A release can be cut from any commit that already carries the workflow files, not only `main`'s head:
 
-1. Bump version with `hatch version <rule>`, commit, tag `u<version>`, push.
-2. The Changelog workflow (triggered by the `u` tag) generates `CHANGELOG.md`, commits it, creates the `v` tag, and pushes.
-3. The Release workflow (triggered via `workflow_run` after Changelog) creates a GitHub Release with GitHub auto-generated notes.
+1. Check out the commit to release, bump the version with `hatch version <rule>` (this commits and creates the annotated `u<version>` tag), and push only that tag (`git push origin u<version>`).
+2. The Changelog workflow (triggered by the `u` tag) creates a `release/<version>` branch at the tagged commit, generates `CHANGELOG.md` and the `v` tag on it, then merges the branch back into `main` when the release is on `main`'s line and its history already contains the newest existing release. Otherwise it is a backport: the merge-back is skipped with a warning, the branch is kept, and `main` is untouched.
+3. The Release workflow (triggered via `workflow_run` after Changelog) creates a GitHub Release with GitHub auto-generated notes, marking it latest and moving the `latest` tag only when it is the newest version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,16 @@ Releases use a two-tag flow. The `u` tag triggers changelog generation, which in
 
    Where `<rule>` is `patch`, `minor`, or `major`. This updates `src/legendary_octo_happiness/__about__.py`, creates a commit, and tags it `u<version>`.
 
-2. **Push the commit and tag:**
+2. **Push the tag:**
 
    ```bash
-   git push origin main --tags
+   git push origin u<version>
    ```
 
+   Push only the `u` tag, not `main --tags`: a stale local `latest` tag makes `--tags` fail. GitHub Actions publishes the changelog commit and the other tags back to you.
+
 3. **Wait for CI:**
-   - The **Changelog** workflow generates `CHANGELOG.md`, commits it to `main`, and creates the `v` tag.
-   - The **Release** workflow then creates a GitHub Release with categorized notes.
+   - The **Changelog** workflow creates a `release/<version>` branch at the tagged commit, generates `CHANGELOG.md` and the `v` tag on it, then merges the branch back into `main` (a backport, cut from a commit off `main`'s line, keeps the branch and leaves `main` untouched).
+   - The **Release** workflow then creates a GitHub Release with categorized notes, marking it latest only when it is the newest version.
+
+To release from an older commit rather than `main`'s head, check that commit out first (`git switch --detach <commit>`); see the README's "Release process" for the full runbook.


### PR DESCRIPTION
## Summary

Aligns the two release descriptions that still assumed the changelog was committed straight to `main` with the new release-branch model landed in #38.

- **`CONTRIBUTING.md`** — "Push the tag" now pushes only the `u` tag (`git push origin main --tags` fails once a stale local `latest` tag exists, confirmed empirically), and the "Wait for CI" bullets describe the `release/<version>` branch, the merge-back, the backport case, and the latest-when-newest rule. Adds a pointer to the README runbook for releasing from an older commit.
- **`.claude/CLAUDE.md`** — the "Releases" section now describes the per-release branch, the conditional merge-back, and the backport case.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
