### PR TITLE
chore: extract persona-review profile from write-readme skill

### DIFF
--- a/.claude/rules/persona-review-engine.md
+++ b/.claude/rules/persona-review-engine.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - ".claude/skills/write-readme/SKILL.md"
+  - ".claude/rules/persona-review-profile.md"
+---
+
+# Persona-review engine
+
+The body of `.claude/skills/write-readme/SKILL.md` is repository-agnostic,
+to be eventually extracted as a plugin: every repository-specific value
+lives in `.claude/rules/persona-review-profile.md`, whose `##` headings are
+the interface the engine reads by name.

--- a/.claude/rules/persona-review-profile.md
+++ b/.claude/rules/persona-review-profile.md
@@ -1,0 +1,97 @@
+# Persona-review profile
+
+Repository-specific values for the persona-review engine in
+`.claude/skills/write-readme/SKILL.md`. The engine reads this file first
+and refers to its sections by name; the section structure is shared with
+the counterpart profile in hypothesis-awkward.
+
+## Document
+
+The document is `README.md`, the repository's only document; the unit of
+work is the whole document. The section set is an output of the run.
+Provenance: the workflow was adapted from hypothesis-awkward's
+`write-docs-page` skill — there the unit of work is one page and the site
+grows page by page; here it is the whole document.
+
+## Personas
+
+The five review personas are the `readme-persona-*` subagents in
+`.claude/agents/`: `adopter`, `release-operator`, `ci-expert`,
+`evaluator`, and `ai`. The primary personas are chosen when the run is
+scoped (step 1).
+
+## Declaration mechanism
+
+Each section's Diátaxis quadrant is declared by the visible marker in its
+heading. The Diátaxis rules are `.claude/rules/diataxis-review.md`, which
+holds the marker legend, the one-quadrant-per-section rule, and the
+bleed/relocation rules. Every section belongs to exactly one quadrant;
+there are no sanctioned multi-quadrant sections — a heading whose
+subsections span quadrants is an unmarked container with at most an
+orientation sentence of its own. Declarations travel with the text: each
+draft and the shipped README declare their own structure through their
+heading markers, and the review brief carries each section's status and
+reader question, not its quadrant. Out-of-scope asks and bleed are routed
+to the owning section within the README, creating or removing sections as
+the content requires.
+
+## Premise to pin
+
+Trigger: spec content. Premise: the feature semantics — the design
+decisions the text must encode. Authority: the design brief.
+
+## Sources
+
+`.github/workflows/*`; the marketplace actions' `action.yml` (fetch the
+currently pinned versions); `CONTRIBUTING.md`; `.claude/CLAUDE.md`; the
+supplied design brief for spec content; and the repository settings the
+workflows assume.
+
+## Fact-check targets
+
+For implemented content: the actual workflow files; the actions' inputs
+and outputs; the repository settings; and every link (confirm each
+resolves). For spec content: the implementability platform is GitHub
+Actions.
+
+## Status dimension
+
+Enabled. For implemented content the source of truth is the workflow files
+and actions. Spec status is how this repository practices README-driven
+development: the feature is settled in prose first, and the settled text
+binds the implementation that follows.
+
+## Verification
+
+No one-time wiring. Checks, re-run each review round: the `/review-readme`
+audit — local links resolve, and the workflows table matches the actual
+workflow files and their triggers — and the voice check against
+`.claude/rules/docs-voice.md` (MD040 fences, aligned tables, ~80-column
+wrap, reference-style links, examples alongside patterns).
+
+## Record
+
+List every section-set change (added, split, merged, removed,
+reclassified) in the report. The shipped README's heading markers are
+themselves the declaration record; there is no table to sync.
+
+## Voice rules
+
+`.claude/rules/docs-voice.md`.
+
+## Extra guidelines
+
+- The actor of every step must be explicit — "User" or "GitHub Actions" —
+  in how-to sections; the release-operator persona enforces this.
+- Reclassification — changing a section's declared quadrant while keeping
+  its content — is a scoping decision (step 1, or the user's call between
+  runs), never a review-round outcome. The declaration is the fixed point
+  a round reviews against; reviewer remedies move content, not
+  declarations. A section that drains through relocations and disappears
+  while a similar heading grows elsewhere may look reclassified in the
+  end, and a section that sheds bleed into a newly added section of
+  another quadrant may look split across quadrants; in both cases the net
+  result is composed of relocation plus add or remove — no declaration
+  moved and no single step crossed a quadrant.
+- Keep `/review-readme` as the maintenance audit; this skill is for
+  authoring and substantial revision.

--- a/.claude/skills/write-readme/SKILL.md
+++ b/.claude/skills/write-readme/SKILL.md
@@ -4,170 +4,162 @@ description:
   Author or substantially revise README.md via the persona-review workflow
 ---
 
-Author (or substantially revise) `README.md` using the persona-review
-workflow adapted from hypothesis-awkward's `write-docs-page` skill. There
-the unit of work is one page and the site grows page by page; here the unit
-of work is the whole document. A revision may be triggered by one feature or
-one weak section, but drafting, review, and shipping cover the README as a
-whole, and the **section set is an output of the run**: sections are added,
-split, merged, and removed as the content requires. The goal is a document
-whose sections each serve their primary personas and are accurate;
-**accuracy beats style**.
+Every repository-specific value lives in this repository's
+`.claude/rules/persona-review-profile.md` (the profile); read it first. The
+profile supplies, by section: Document, Personas, Declaration mechanism, Premise
+to pin, Sources, Fact-check targets, Status dimension, Verification, Record,
+Voice rules, and Extra guidelines. In this file, "the Diátaxis rules" refers to
+the rules file named in the profile's Declaration mechanism section, and "the
+voice rules" to the file named in its Voice rules section.
 
-The five review personas are the `readme-persona-*` subagents in
-`.claude/agents/`: `adopter`, `release-operator`, `ci-expert`, `evaluator`,
-and `ai`.
+Author (or substantially revise) the document defined in the profile's Document
+section using the persona-review workflow. A revision may be triggered by one
+change or one weak part, but drafting, review, and shipping cover the document
+as a whole. When the profile's Document section declares the **section set an
+output of the run**, sections are added, split, merged, and removed as the
+content requires. The goal is a document whose content serves its primary
+personas and is accurate; **accuracy beats style**. The review personas are the
+subagents listed in the profile's Personas section.
 
-Every section of the document is declared in a **quadrant** and a
-**status**:
-
-- Quadrant — the section's [Diátaxis](https://diataxis.fr/) quadrant
-  (tutorial, how-to, reference, or explanation), declared by the visible
-  marker in the section's heading; `.claude/rules/diataxis-review.md` holds
-  the marker legend, the one-quadrant-per-section rule, and the
-  bleed/relocation rules.
-- Status — *implemented* (describes current behavior; source of truth is the
-  workflow files and actions) or *spec* (describes intended behavior; source
-  of truth is a design brief supplied when the skill is invoked — a decision
-  list or note that need not live in the repository). Spec status is how this
-  repository practices README-driven development: the feature is settled in
-  prose first, and the settled text binds the implementation that follows.
+Every unit of content is declared in a [Diátaxis](https://diataxis.fr/) quadrant
+(tutorial, how-to, reference, or explanation) as the profile's Declaration
+mechanism section directs; the Diátaxis rules hold the reader questions and the
+bleed and out-of-scope rules. When the profile's Status dimension section is
+enabled, every unit also carries a **status** — _implemented_ (describes current
+behavior; verified against the profile's Fact-check targets) or _spec_
+(describes intended behavior; source of truth is a design brief supplied when
+the skill is invoked — a decision list or note that need not live in the
+repository).
 
 ## Steps
 
-1. **Scope** — Confirm the change driving the revision and its status
-   (implemented or spec), the personas it primarily serves (whose verdicts
-   outweigh the others when fixes conflict), and what is out of scope.
-   Sketch the target section set — starting from the heading markers in the
-   shipped README, adding, splitting, merging, or removing sections as the
-   content requires — and assign each section a quadrant marker. For spec
-   status, capture the design decisions the text must encode into the
-   review brief (step 5) so the brief is self-contained.
+1. **Scope** — Confirm the change driving the revision, the unit of work, and
+   what is out of scope; confirm the primary personas (whose verdicts outweigh
+   the others when fixes conflict) as the profile's Personas section directs;
+   and confirm the declared quadrant(s) per the Declaration mechanism, noting
+   the matching reader question(s) from the Diátaxis rules. Apply any scoping
+   notes in the profile's Document section. When the section set is an output of
+   the run, sketch the target section set — starting from the current
+   declarations, adding, splitting, merging, or removing sections as the content
+   requires — and declare each section's quadrant. When the status dimension is
+   enabled, confirm the change's status; for spec status, capture the design
+   decisions the text must encode into the review brief (step 5) so the brief is
+   self-contained.
 
-2. **Gather sources** — Collect the raw material: `.github/workflows/*`, the
-   marketplace actions' `action.yml` (fetch the currently pinned versions),
-   `CONTRIBUTING.md`, `.claude/CLAUDE.md`, the supplied design brief for spec
-   content, and the repository settings the workflows assume.
+2. **Gather sources** — Collect the raw material listed in the profile's Sources
+   section.
 
 3. **Rubric** — Itemize what the document must say (Content), must be true
-   (Accuracy), must exclude (Exclusions), and must satisfy editorially
-   (`.claude/rules/docs-voice.md`). For spec content, pin the feature
-   semantics first — the design decisions the text must encode. All three
-   drafts inherit the semantics, so a wrong decision poisons them
-   identically and the persona pass will not reliably catch it; settle
-   semantics against the design brief before drafting.
+   (Accuracy), must exclude (Exclusions), and must satisfy editorially (the
+   voice rules). When the trigger named in the profile's Premise to pin section
+   applies, pin the named premise first. All three drafts inherit the premise,
+   so a wrong one poisons them identically and the persona pass will not
+   reliably catch it; settle the premise before drafting, against the authority
+   the profile names, if it names one.
 
-4. **Diverse drafts** — Write three structurally distinct whole-README
-   drafts, all meeting the rubric. Section structure is part of the
-   variation: drafts may differ in how many sections exist and how content
-   is distributed among them, as long as each draft keeps every section in
-   exactly one quadrant. Write the drafts to scratchpad files; each draft
-   declares its own structure through the markers in its headings.
+4. **Diverse drafts** — Write three structurally distinct drafts of the whole
+   document, all meeting the rubric, to temp files. When the section set is an
+   output of the run, structure is part of the variation: drafts may differ in
+   how many sections exist and how content is distributed among them, as long as
+   each draft keeps its declarations valid per the Declaration mechanism and
+   declares its own structure. Otherwise, vary only the framing and order.
 
-5. **Parallel persona review** — Launch the five persona subagents in
-   parallel via the Agent tool's `subagent_type`. Write a shared review brief
-   (the document's purpose; each section's status and reader question —
-   quadrants are declared by the drafts' own heading markers; what is in
-   and out of scope; rubric; verified facts; link targets) to a temp file
-   and pass each subagent its path plus the draft paths. For spec content the brief itself carries the
-   design decisions — subagents never depend on files outside the repository
-   and the brief. Ask each for: answers to the reader questions for the
-   sections its lens serves; a score per draft on the rubric axes;
-   lens-specific flags with quoted text and `file:line` citations; how
-   relevant each section is to it; the best draft overall and per axis;
-   specific fixes; structural recommendations (sections to add, split,
-   merge, or remove); the single most important improvement; an alignment
-   self-check (relocations and bleed flagged — see
-   `.claude/rules/diataxis-review.md`); and a one-line ship/revise verdict
-   (with the single most important change if revising). Consolidate into a
-   matrix. If a reviewer errors out mid-run, re-launch it — do not treat a
-   missing verdict as a pass.
+5. **Parallel persona review** — Launch the persona subagents listed in the
+   profile's Personas section in parallel via the Agent tool's `subagent_type`.
+   Write a shared review brief — the document's purpose; the declared
+   quadrant(s) and matching reader question(s), carried as the Declaration
+   mechanism directs; when the status dimension is enabled, each unit's status;
+   what is in and out of scope; rubric; verified facts; link targets — to a temp
+   file and pass each subagent its path plus the draft paths. Subagents never
+   depend on files outside the repository and the brief; when the status
+   dimension is enabled, the brief itself carries the design decisions for spec
+   content. Ask each for: answers to the reader questions for the content its
+   lens serves; a score per draft on the rubric axes; lens-specific flags with
+   quoted text and `file:line` citations; how relevant the document is to it
+   (per section, when the section set is an output of the run); the best draft
+   overall and per axis; specific fixes; structural recommendations (sections to
+   add, split, merge, or remove) when the section set is an output of the run;
+   the single most important improvement; an alignment self-check per the
+   Diátaxis rules (out-of-scope asks and their routing; bleed flagged); and a
+   one-line ship/revise verdict (with the single most important change if
+   revising). Consolidate into a matrix. If a reviewer errors out mid-run,
+   re-launch it — do not treat a missing verdict as a pass. This pass validates
+   lens-relevance and accuracy, not framing or altitude; the re-review step
+   below covers that.
 
-6. **Fact-check** — For implemented content, verify every claim against the
-   actual workflow files, the actions' inputs/outputs, and the repository
-   settings, and confirm every link resolves. For spec content, verify every
-   claim against the design decisions in the brief, and verify
-   implementability: a behavior GitHub Actions cannot deliver as written is a
+6. **Fact-check** — Verify every claim and code example against the targets in
+   the profile's Fact-check targets section, applying its checking notes. When
+   the status dimension is enabled, verify spec content against the design
+   decisions in the brief, and verify implementability on the platform the
+   profile names: a behavior the platform cannot deliver as written is a
    blocking defect. Accuracy beats style.
 
-7. **Synthesize or select** — First, if the review surfaced a flaw shared by
-   all three drafts (most often wrong or missing semantics), fix it across
-   the drafts and re-review once or twice before proceeding. Then produce the
-   document: when strengths are split across drafts, merge the per-axis
-   winners; when one draft is strongest on most axes, take it as the base and
-   graft only the specific wins from the others. Merging adds seams, so do
-   not merge for its own sake. Write the final text yourself, following
-   `.claude/rules/docs-voice.md` — persona-suggested wording is advisory.
+7. **Synthesize or select** — First, if the review surfaced a flaw shared by all
+   three drafts (most often a flaw in the pinned premise), fix it across the
+   drafts and re-review once or twice before proceeding — the diverse drafts
+   only help once the shared premise is right. Then produce the document: when
+   strengths are split across drafts, merge the per-axis winners; when one draft
+   is strongest on most axes, take it as the base and graft only the specific
+   wins from the others. Merging adds seams, so do not merge for its own sake.
+   Apply cross-cutting fixes and write the final text yourself, following the
+   voice rules — persona-suggested wording is advisory. An ask a persona flagged
+   out of scope, and any content flagged as bleed, is routed to the destination
+   named in the profile's Declaration mechanism section — not folded in where it
+   does not belong.
 
-8. **Re-review the resulting README** — The draft review does not cover the
-   text you will ship: a merge can inherit a weakness shared by all drafts,
-   and an edited draft carries changes no reviewer saw. Run the personas
-   again on the resulting document (same brief; the resulting README's own
-   heading markers carry the current declarations, however many sections a
-   round has added, split, merged, or removed), apply the genuine fixes,
-   and re-review — iterating until all five return a "ship" verdict (cap at
-   five rounds). Re-run the
-   mechanical checks each round, since a fix can introduce a new error. If
-   the cap is reached with dissent remaining, stop and present the
-   unresolved verdicts to the user — do not keep bending the text to chase
-   the last holdout.
+8. **Re-review the resulting document** — The draft review (step 5) does not
+   cover the text you will ship: a merge can inherit a weakness shared by all
+   three drafts, and a chosen-and-edited draft carries changes no reviewer saw.
+   Run the personas again on the resulting document (same brief; the
+   declarations travel with the text as the Declaration mechanism directs,
+   however much a round has changed), apply the genuine fixes within the
+   declared quadrant(s), and re-review — iterating until every persona returns a
+   "ship" verdict (cap at five rounds). Re-run the checks in the profile's
+   Verification section each round, since a fix can introduce a new error. If
+   the cap is reached with dissent remaining, stop and present the unresolved
+   verdicts to the user — do not keep bending the text to chase the last
+   holdout.
 
-9. **Verify mechanically** — Run the `/review-readme` audit: local links
-   resolve, and the workflows table matches the actual workflow files and
-   their triggers. Check the text against the conventions in
-   `.claude/rules/docs-voice.md` (MD040 fences, aligned tables, ~80-column
-   wrap, reference-style links, examples alongside patterns).
+9. **Verify** — Work through the profile's Verification section: perform any
+   one-time wiring it lists, then run its checks.
 
-10. **Record** — List every section-set change (added, split, merged,
-    removed, reclassified) in the report; the shipped README's heading
-    markers are themselves the declaration record, so there is no table to
-    sync. For spec content, list the claims that describe intended behavior
-    in the implementation plan, so each is re-verified against the real
-    workflows after the implementation ships.
+10. **Record** — Record the run as the profile's Record section directs. When
+    the status dimension is enabled, list the claims that describe intended
+    behavior in the implementation plan, so each is re-verified against the
+    shipped implementation.
 
 ## Guidelines
 
-- `README.md` is the only document: a section is written well when its
-  primary personas find what they need and the others can tell early that it
-  is not for them while still seeing it is useful to its own readers.
-- A section is not obligated to serve every persona, and the document does
-  not owe any persona a section. The correct review from a low-relevance
-  persona is a low relevance score and a ship verdict — not asks that bend
-  the document toward its lens. When personas' fixes conflict, the primary
-  personas from step 1 win.
-- The section set is an output of the run: relocating bleed, creating the
-  section a quadrant needs, and removing a section that no longer serves
-  anyone are actions the run takes, guided by persona feedback. Removal has
-  exactly two legitimate sources: a persona speaking as the section's own
-  audience (duplication, void purpose, vanished subject), or the
-  consolidated matrix showing a section every persona finds low-relevance —
-  the latter is the orchestrator's judgment at synthesis, never a single
-  low-relevance persona's ask. Every section-set change is listed in the
-  report; an ask the run chooses not to serve is reported with a keep/drop
-  recommendation for the user.
-- Reclassification — changing a section's declared quadrant while keeping
-  its content — is a scoping decision (step 1, or the user's call between
-  runs), never a review-round outcome. The declaration is the fixed point a
-  round reviews against; reviewer remedies move content, not declarations.
-  A section that drains through relocations and disappears while a similar
-  heading grows elsewhere may look reclassified in the end, and a section
-  that sheds bleed into a newly added section of another quadrant may look
-  split across quadrants; in both cases the net result is composed of
-  relocation plus add or remove — no declaration moved and no single step
-  crossed a quadrant.
-- In spec status the design decisions in the brief are settled. A persona
-  ask that would change a decision is design feedback: surface it in the
-  report for the user to rule on; never fold it into the text as if settled.
-- Every section belongs to exactly one Diátaxis quadrant; a heading whose
-  subsections span quadrants is an unmarked container with at most an
-  orientation sentence of its own. Bleed is relocated, not polished in
-  place (see `.claude/rules/diataxis-review.md`).
-- The actor of every step must be explicit — "User" or "GitHub Actions" —
-  in how-to sections; the release-operator persona enforces this.
-- A spec section binds the implementation. After the implementation ships,
-  a difference between behavior and the section is either an implementation
-  bug or a change that re-enters this skill — never a silent doc drift.
-- Keep `/review-readme` as the maintenance audit; this skill is for
-  authoring and substantial revision.
-- Voice and formatting follow `.claude/rules/docs-voice.md`; the orchestrator
-  writes the final text, not the personas.
+- A unit of content is written well when its primary personas find what they
+  need and the others can tell early that it is not for them while still seeing
+  it is useful to its own readers.
+- Content is not obligated to serve every persona, and the document does not owe
+  any persona content. The correct review from a low-relevance persona is a low
+  relevance score and a ship verdict — not asks that bend the document toward
+  its lens. When personas' fixes conflict, the primary personas from step 1 win.
+- When the section set is an output of the run: relocating bleed, creating the
+  section a quadrant needs, and removing a section that no longer serves anyone
+  are actions the run takes, guided by persona feedback. Removal has exactly two
+  legitimate sources: a persona speaking as the section's own audience
+  (duplication, void purpose, vanished subject), or the consolidated matrix
+  showing a section every persona finds low-relevance — the latter is the
+  orchestrator's judgment at synthesis, never a single low-relevance persona's
+  ask. Every section-set change is listed in the report; an ask the run chooses
+  not to serve is reported with a keep/drop recommendation for the user.
+- When the status dimension is enabled: the design decisions in the brief are
+  settled for spec content. A persona ask that would change a decision is design
+  feedback — surface it in the report for the user to rule on; never fold it
+  into the text as if settled. A spec unit binds the implementation: after the
+  implementation ships, a difference between behavior and the text is either an
+  implementation bug or a change that re-enters this skill — never a silent doc
+  drift.
+- Declarations, their granularity, and what counts as a sanctioned combination
+  of quadrants follow the profile's Declaration mechanism section; undeclared
+  cross-quadrant content is bleed. Personas review and route by quadrant per the
+  Diátaxis rules: a lens asking for content outside a unit's declared mode — for
+  example runnable how-to steps in explanation content — is out of scope, not a
+  defect; route it (and any bleed) to the destination the profile names instead
+  of folding it in. Bleed is relocated or routed, never polished in place.
+- Voice and formatting follow the voice rules; the orchestrator writes the final
+  text, not the personas.
+- Apply the additional guidelines in the profile's Extra guidelines section.


### PR DESCRIPTION
Part of #49 (iteration 1 — profile seam and engine convergence). Paired with the counterpart PR in scikit-hep/hypothesis-awkward: scikit-hep/hypothesis-awkward#160.

## What

- The `.claude/skills/write-readme/SKILL.md` body becomes a repository-agnostic engine: values become profile references, one-repository machinery becomes conditional modules gated by the profile ("when the status dimension is enabled…", "when the section set is an output of the run…"), and parallel wordings unify.
- New `.claude/rules/persona-review-profile.md` carries every repository-specific fact under the 11 section headings the engine reads by name (Document, Personas, Declaration mechanism, Premise to pin, Sources, Fact-check targets, Status dimension, Verification, Record, Voice rules, Extra guidelines).
- New `.claude/rules/persona-review-engine.md`, path-scoped to the two files above, records the seam: the body is repository-agnostic and plugin-bound.
- The body is shared verbatim with scikit-hep/hypothesis-awkward's `write-docs-page` skill and is prettier-formatted, because that repository's pre-commit hook enforces prettier on Markdown.

## Definition of done (from #49)

- Mirror: the two `SKILL.md` bodies diff clean below the frontmatter, verified across the paired branches; the check against the counterpart's `main` holds once both PRs merge.
- Ledger: every deleted repository-specific line reappears in the profile, and shared machinery reappears generalized in the engine — nothing dropped, nothing invented.
- Smoke check: a fresh subagent reading only engine + profile answered — step 2: `.github/workflows/*`, the pinned `action.yml`s, `CONTRIBUTING.md`, `.claude/CLAUDE.md`, the design brief for spec content, and the repository settings; step 5: the five `readme-persona-*` subagents in parallel; step 9: the `/review-readme` audit plus the docs-voice checks. Status dimension enabled; section set an output of the run. All match the pre-refactor skill.

## Untouched

Frontmatter, the five persona agents, `diataxis-review.md`, `docs-voice.md`, `review-readme`, and CLAUDE.md wiring are unchanged; behavior is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
